### PR TITLE
Remove also oncontextmenu attribute

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -45,6 +45,7 @@ function handlePointerPress(e) {
     // return google.arwt(this); // E.g. sponsored search results (dec 2016).
     if (inlineMousedown && /\ba?rwt\(/.test(inlineMousedown)) {
         a.removeAttribute('onmousedown');
+        a.removeAttribute('oncontextmenu');
         // Just in case:
         a.removeAttribute('ping');
         // In Chrome, removing onmousedown during event dispatch does not


### PR DESCRIPTION
Google search results' hyperlinks also contain now the `oncontextmenu` attribute, calling some internal JS function.

By the way, I have successful integrated your `contentscript.js` in [Bromite](https://www.bromite.org/) and it will be released in next version.