### PR TITLE
Open search links in new tabs

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -4,15 +4,18 @@ document.addEventListener('click', handleClick, true);
 setupAggresiveUglyLinkPreventer();
 blockTrackingBeacons();
 
+var openInNewTab = false;
 var forceNoReferrer = true;
 if (typeof chrome == 'object' && chrome.storage) {
     (chrome.storage.sync || chrome.storage.local).get({
+        openInNewTab: false,
         forceNoReferrer: true,
         // From version 4.7 until 4.11, the preference was the literal value of
         // the referrer policy.
         referrerPolicy: 'no-referrer',
     }, function(items) {
         if (items) {
+            openInNewTab = items.openInNewTab;
             // Migration code (to be removed in the future).
             if (items.referrerPolicy === '') {
                 // User explicitly allowed referrers to be sent, respect that.
@@ -56,6 +59,9 @@ function handlePointerPress(e) {
     var realLink = getRealLinkFromGoogleUrl(a);
     if (realLink) {
         a.href = realLink;
+    }
+    if (openInNewTab) {
+        a.target = "_blank";
     }
     a.referrerPolicy = getReferrerPolicy();
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Don't track me Google",
     "description": "Removes the annoying link-conversion at Google Search/maps/...",
-    "version": "4.21",
+    "version": "4.22",
     "manifest_version": 2,
     "content_scripts": [
         {

--- a/options.html
+++ b/options.html
@@ -24,6 +24,10 @@ footer {
     <input type="checkbox" id="noreferrer">
     Clear HTTP referrer (this prevents other sites from seeing your Google search terms).
 </label>
+<label>
+    <input type="checkbox" id="newtab">
+    Open links in new tab.
+</label>
 <footer>
     &copy; 2011 - 2018 Rob Wu &lt;rob@robwu.nl&gt;
     &bull; <a href="https://github.com/Rob--W/dont-track-me-google/">Source code on Github</a>

--- a/options.js
+++ b/options.js
@@ -1,17 +1,29 @@
 var storageArea = chrome.storage.sync || chrome.storage.local;
 var noreferrerCheckbox = document.getElementById('noreferrer');
+var newtabCheckbox = document.getElementById('newtab');
+
+newtabCheckbox.onchange = function() {
+    storageArea.set({
+        openInNewTab: newtabCheckbox.checked,
+    });
+};
+
 noreferrerCheckbox.onchange = function() {
     storageArea.remove('referrerPolicy');
     storageArea.set({
         forceNoReferrer: noreferrerCheckbox.checked,
     });
 };
+
 storageArea.get({
-    forceNoReferrer: true,
+    openInNewTab: false,
     referrerPolicy: 'no-referrer',
+    forceNoReferrer: true,
 }, function(items) {
     if (items.referrerPolicy === '') {
         items.forceNoReferrer = false;
     }
+
+    newtabCheckbox.checked = items.openInNewTab;
     noreferrerCheckbox.checked = items.forceNoReferrer;
 });


### PR DESCRIPTION
This adds an option (disabled by default) that forces all links to be opened in a new tab.
This is relevant to me because I use this extension alongside `Google Container`, and I thought it could be useful to other people.