### PR TITLE
Removed locale strings from URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![](screenshot.png)
 
-- Firefox: https://addons.mozilla.org/en-US/firefox/addon/dont-track-me-google1/ (Firefox on Android is also supported).
+- Firefox: https://addons.mozilla.org/addon/dont-track-me-google1/ (Firefox on Android is also supported).
 - Chrome: https://chrome.google.com/webstore/detail/dont-track-me-google/gdbofhhdmcladcmmfjolgndfkpobecpg
-- Opera: https://addons.opera.com/en/extensions/details/dont-track-me-google/
+- Opera: https://addons.opera.com/extensions/details/dont-track-me-google/
 
 At the Google Search engine, search results are converted to an ugly link upon click. This link enables tracking for Google.
 

--- a/options.html
+++ b/options.html
@@ -28,8 +28,8 @@ footer {
     &copy; 2011 - 2018 Rob Wu &lt;rob@robwu.nl&gt;
     &bull; <a href="https://github.com/Rob--W/dont-track-me-google/">Source code on Github</a>
     &bull; <a href="https://chrome.google.com/webstore/detail/dont-track-me-google/gdbofhhdmcladcmmfjolgndfkpobecpg">Chrome Web Store listing</a>
-    &bull; <a href="https://addons.mozilla.org/firefox/addon/dont-track-me-google1/">Firefox addon listing</a>
-    &bull; <a href="https://addons.opera.com/en/extensions/details/dont-track-me-google/">Opera addon listing</a>
+    &bull; <a href="https://addons.mozilla.org/dont-track-me-google1/">Firefox addon listing</a>
+    &bull; <a href="https://addons.opera.com/extensions/details/dont-track-me-google/">Opera addon listing</a>
 </footer>
 <script src="options.js"></script>
 </body>

--- a/options.html
+++ b/options.html
@@ -28,7 +28,7 @@ footer {
     &copy; 2011 - 2018 Rob Wu &lt;rob@robwu.nl&gt;
     &bull; <a href="https://github.com/Rob--W/dont-track-me-google/">Source code on Github</a>
     &bull; <a href="https://chrome.google.com/webstore/detail/dont-track-me-google/gdbofhhdmcladcmmfjolgndfkpobecpg">Chrome Web Store listing</a>
-    &bull; <a href="https://addons.mozilla.org/dont-track-me-google1/">Firefox addon listing</a>
+    &bull; <a href="https://addons.mozilla.org/addon/dont-track-me-google1/">Firefox addon listing</a>
     &bull; <a href="https://addons.opera.com/extensions/details/dont-track-me-google/">Opera addon listing</a>
 </footer>
 <script src="options.js"></script>


### PR DESCRIPTION
So that the extension pages will open in the user's preferred language.